### PR TITLE
Add attr_reader for goal attribute frozen

### DIFF
--- a/lib/beeminder/goals.rb
+++ b/lib/beeminder/goals.rb
@@ -59,6 +59,9 @@ module Beeminder
 
     # @return [Beeminder::User] User that owns this goal.
     attr_reader :user
+
+    # @return [true|false] Whether the goal is currently frozen and therefore must be restarted before continuing to accept data.
+    attr_reader :frozen
     
     def initialize user, name_or_info
       @user = user


### PR DESCRIPTION
Didn't seem like there was a way to access the frozen attribute without adding another attr_reader. Let me know if I'm mistaken.

Seems like there are a few more attributes that aren't currently accessible (won, lost, for example) but I didn't need them for my current project, so didn't add.