### PR TITLE
Add require to fix autoload errors occuring on deploy

### DIFF
--- a/lib/beeminder.rb
+++ b/lib/beeminder.rb
@@ -1,5 +1,6 @@
 # coding: utf-8
 
+require 'active_support'
 require 'active_support/core_ext'
 require 'date'
 require 'json'


### PR DESCRIPTION
I intermittently got a `uninitialized constant ActiveSupport::Autoload (NameError)` error when trying to deploy an app with the beeminder gem. I think the issue is the same one described in  https://github.com/rails/rails/issues/14664, which pointed out this quick fix.