### PR TITLE
Bump for recent activesupport version

### DIFF
--- a/beeminder.gemspec
+++ b/beeminder.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'activesupport', ['>= 3.2', '< 5']
+  gem.add_dependency 'activesupport', ['>= 3.2', '< 6']
   gem.add_dependency 'chronic', '~> 0.7'
   gem.add_dependency 'json'
   gem.add_dependency 'highline', '~> 1.6'

--- a/lib/beeminder/version.rb
+++ b/lib/beeminder/version.rb
@@ -1,3 +1,3 @@
 module Beeminder
-  VERSION = "0.2.10"
+  VERSION = "0.2.11"
 end


### PR DESCRIPTION
Activesupport 5 is current and compatible. Fixes #16. 