### PR TITLE
Bump activesupport dependency to support ruby 3.4

### DIFF
--- a/beeminder.gemspec
+++ b/beeminder.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'activesupport', ['>= 3.2', '< 7']
+  gem.add_dependency 'activesupport', ['>= 3.2', '< 8']
   gem.add_dependency 'chronic', '~> 0.7'
   gem.add_dependency 'json'
   gem.add_dependency 'highline', '~> 1.6'


### PR DESCRIPTION
This seems to fix https://github.com/beeminder/beeminder-gem/issues/35 and lets me run the gem on ruby 3.4